### PR TITLE
Add hash160 support for public key verification

### DIFF
--- a/Backup.cpp
+++ b/Backup.cpp
@@ -159,6 +159,7 @@ bool Kangaroo::LoadWork(string &fileName) {
       return false;
 
     keysToSearch.clear();
+    keysHash160.clear();
     Point key;
 
     // Read global param
@@ -179,6 +180,10 @@ bool Kangaroo::LoadWork(string &fileName) {
     }
 
     keysToSearch.push_back(key);
+    uint8_t h[20];
+    GetPubKeyHash160(key,h);
+    keysHash160.push_back(std::array<uint8_t,20>());
+    memcpy(keysHash160.back().data(),h,20);
 
     ::printf("Start:%s\n",rangeStart.GetBase16().c_str());
     ::printf("Stop :%s\n",rangeEnd.GetBase16().c_str());

--- a/Check.cpp
+++ b/Check.cpp
@@ -219,7 +219,12 @@ void Kangaroo::CheckPartition(int nbCore,std::string& partName) {
 
   // Set starting parameters
   keysToSearch.clear();
+  keysHash160.clear();
   keysToSearch.push_back(k1);
+  uint8_t h[20];
+  GetPubKeyHash160(k1,h);
+  keysHash160.push_back(std::array<uint8_t,20>());
+  memcpy(keysHash160.back().data(),h,20);
   keyIdx = 0;
   collisionInSameHerd = 0;
   rangeStart.Set(&RS1);
@@ -334,7 +339,12 @@ void Kangaroo::CheckWorkFile(int nbCore,std::string& fileName) {
 
   // Set starting parameters
   keysToSearch.clear();
+  keysHash160.clear();
   keysToSearch.push_back(k1);
+  uint8_t h2[20];
+  GetPubKeyHash160(k1,h2);
+  keysHash160.push_back(std::array<uint8_t,20>());
+  memcpy(keysHash160.back().data(),h2,20);
   keyIdx = 0;
   collisionInSameHerd = 0;
   rangeStart.Set(&RS1);
@@ -477,7 +487,12 @@ void Kangaroo::Check(std::vector<int> gpuId,std::vector<int> gridSize) {
     Point P = secp->ComputePublicKey(&k1);
     CreateJumpTable();
     keysToSearch.clear();
+    keysHash160.clear();
     keysToSearch.push_back(P);
+    uint8_t h3[20];
+    GetPubKeyHash160(P,h3);
+    keysHash160.push_back(std::array<uint8_t,20>());
+    memcpy(keysHash160.back().data(),h3,20);
     keyIdx = 0;
     InitRange();
     InitSearchKey();

--- a/Kangaroo.cpp
+++ b/Kangaroo.cpp
@@ -20,6 +20,7 @@
 #include "SECPK1/IntGroup.h"
 #include "Timer.h"
 #include <string.h>
+#include <sstream>
 #define _USE_MATH_DEFINES
 #include <math.h>
 #include <algorithm>
@@ -123,15 +124,60 @@ bool Kangaroo::ParseConfigFile(std::string &fileName) {
 
   rangeStart.SetBase16((char *)lines[0].c_str());
   rangeEnd.SetBase16((char *)lines[1].c_str());
+  keysToSearch.clear();
+  keysHash160.clear();
   for(int i=2;i<(int)lines.size();i++) {
-    
+
+    // Each line can be either:
+    //   PubKey
+    //   Hash160 PubKey
+    std::vector<std::string> tokens;
+    std::string tok;
+    std::istringstream iss(lines[i]);
+    while(iss >> tok) tokens.push_back(tok);
+
+    if(tokens.size() == 0)
+      continue;
+
+    std::string hashHex;
+    std::string pubHex;
+
+    if(tokens.size() == 1) {
+      // Single token, assume it is a public key
+      pubHex = tokens[0];
+    } else {
+      // First token is hash160, second token is public key
+      hashHex = tokens[0];
+      pubHex  = tokens[1];
+    }
+
     Point p;
     bool isCompressed;
-    if( !secp->ParsePublicKeyHex(lines[i],p,isCompressed) ) {
+    if( !secp->ParsePublicKeyHex(pubHex,p,isCompressed) ) {
       ::printf("%s, error line %d: %s\n",fileName.c_str(),i,lines[i].c_str());
       return false;
     }
     keysToSearch.push_back(p);
+
+    uint8_t h[20];
+    if(hashHex.length() > 0) {
+      // Remove optional 0x prefix
+      if(hashHex.rfind("0x",0) == 0 || hashHex.rfind("0X",0) == 0)
+        hashHex = hashHex.substr(2);
+      if(hashHex.length() != 40) {
+        ::printf("%s, error line %d: invalid hash160 %s\n",fileName.c_str(),i,hashHex.c_str());
+        return false;
+      }
+      for(int k=0;k<20;k++) {
+        std::string byteStr = hashHex.substr(k*2,2);
+        h[k] = (uint8_t)strtoul(byteStr.c_str(),NULL,16);
+      }
+    } else {
+      GetPubKeyHash160(p,h);
+    }
+
+    keysHash160.push_back(std::array<uint8_t,20>());
+    memcpy(keysHash160.back().data(),h,20);
 
   }
 
@@ -171,6 +217,15 @@ void Kangaroo::SetDP(int size) {
 
 }
 
+void Kangaroo::GetPubKeyHash160(Point &p, uint8_t out[20]) {
+
+  unsigned char pub[33];
+  pub[0] = p.y.IsEven() ? 0x02 : 0x03;
+  p.x.Get32Bytes(pub + 1);
+  Hash160(pub,33,out);
+
+}
+
 // ----------------------------------------------------------------------------
 
 bool Kangaroo::Output(Int *pk,char sInfo,int sType) {
@@ -194,9 +249,11 @@ bool Kangaroo::Output(Int *pk,char sInfo,int sType) {
     ::printf("\n");
 
   Point PR = secp->ComputePublicKey(pk);
+  uint8_t h[20];
+  GetPubKeyHash160(PR,h);
 
   ::fprintf(f,"Key#%2d [%d%c]Pub:  0x%s \n",keyIdx,sType,sInfo,secp->GetPublicKeyHex(true,keysToSearch[keyIdx]).c_str());
-  if(PR.equals(keysToSearch[keyIdx])) {
+  if(memcmp(h, keysHash160[keyIdx].data(), 20) == 0) {
     ::fprintf(f,"       Priv: 0x%s \n",pk->GetBase16().c_str());
   } else {
     ::fprintf(f,"       Failed !\n");
@@ -226,26 +283,18 @@ bool  Kangaroo::CheckKey(Int d1,Int d2,uint8_t type) {
 
   Int pk(&d1);
   pk.ModAddK1order(&d2);
+#ifdef USE_SYMMETRY
+  pk.ModAddK1order(&rangeWidthDiv2);
+#endif
+  pk.ModAddK1order(&rangeStart);
 
   Point P = secp->ComputePublicKey(&pk);
+  uint8_t h[20];
+  GetPubKeyHash160(P,h);
 
-  if(P.equals(keyToSearch)) {
-    // Key solved    
-#ifdef USE_SYMMETRY
-    pk.ModAddK1order(&rangeWidthDiv2);
-#endif
-    pk.ModAddK1order(&rangeStart);    
-    return Output(&pk,'N',type);
-  }
-
-  if(P.equals(keyToSearchNeg)) {
-    // Key solved
-    pk.ModNegK1order();
-#ifdef USE_SYMMETRY
-    pk.ModAddK1order(&rangeWidthDiv2);
-#endif
-    pk.ModAddK1order(&rangeStart);
-    return Output(&pk,'S',type);
+  if(memcmp(h, keysHash160[keyIdx].data(), 20) == 0) {
+    char sInfo = P.equals(keysToSearch[keyIdx]) ? 'N' : 'S';
+    return Output(&pk,sInfo,type);
   }
 
   return false;

--- a/Kangaroo.h
+++ b/Kangaroo.h
@@ -38,6 +38,8 @@ typedef int SOCKET;
 
 #include <string>
 #include <vector>
+#include <array>
+#include "hash160.h"
 #include "SECPK1/SECP256k1.h"
 #include "HashTable.h"
 #include "SECPK1/IntGroup.h"
@@ -175,6 +177,7 @@ private:
   void InitSearchKey();
   std::string GetTimeStr(double s);
   bool Output(Int* pk,char sInfo,int sType);
+  void GetPubKeyHash160(Point &p, uint8_t out[20]);
 
   // Backup stuff
   void SaveWork(std::string fileName,FILE *f,int type,uint64_t totalCount,double totalTime);
@@ -248,6 +251,7 @@ private:
   int32_t initDPSize;
   uint64_t collisionInSameHerd;
   std::vector<Point> keysToSearch;
+  std::vector<std::array<uint8_t,20>> keysHash160;
   Point keyToSearch;
   Point keyToSearchNeg;
   uint32_t keyIdx;

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ ifdef gpu
 SRC = SECPK1/IntGroup.cpp main.cpp SECPK1/Random.cpp \
       Timer.cpp SECPK1/Int.cpp SECPK1/IntMod.cpp \
       SECPK1/Point.cpp SECPK1/SECP256K1.cpp \
-      GPU/GPUEngine.o Kangaroo.cpp HashTable.cpp \
+      hash160.cpp GPU/GPUEngine.o Kangaroo.cpp HashTable.cpp \
       Backup.cpp Thread.cpp Check.cpp Network.cpp Merge.cpp PartMerge.cpp
 
 OBJDIR = obj
@@ -17,7 +17,7 @@ OBJET = $(addprefix $(OBJDIR)/, \
       SECPK1/IntGroup.o main.o SECPK1/Random.o \
       Timer.o SECPK1/Int.o SECPK1/IntMod.o \
       SECPK1/Point.o SECPK1/SECP256K1.o \
-      GPU/GPUEngine.o Kangaroo.o HashTable.o Thread.o \
+      hash160.o GPU/GPUEngine.o Kangaroo.o HashTable.o Thread.o \
       Backup.o Check.o Network.o Merge.o PartMerge.o)
 
 else
@@ -25,7 +25,7 @@ else
 SRC = SECPK1/IntGroup.cpp main.cpp SECPK1/Random.cpp \
       Timer.cpp SECPK1/Int.cpp SECPK1/IntMod.cpp \
       SECPK1/Point.cpp SECPK1/SECP256K1.cpp \
-      Kangaroo.cpp HashTable.cpp Thread.cpp Check.cpp \
+      hash160.cpp Kangaroo.cpp HashTable.cpp Thread.cpp Check.cpp \
       Backup.cpp Network.cpp Merge.cpp PartMerge.cpp
 
 OBJDIR = obj
@@ -34,7 +34,7 @@ OBJET = $(addprefix $(OBJDIR)/, \
       SECPK1/IntGroup.o main.o SECPK1/Random.o \
       Timer.o SECPK1/Int.o SECPK1/IntMod.o \
       SECPK1/Point.o SECPK1/SECP256K1.o \
-      Kangaroo.o HashTable.o Thread.o Check.o Backup.o \
+      hash160.o Kangaroo.o HashTable.o Thread.o Check.o Backup.o \
       Network.o Merge.o PartMerge.o)
 
 endif
@@ -51,7 +51,7 @@ CXXFLAGS   = -DWITHGPU -m64  -mssse3 -Wno-unused-result -Wno-write-strings -g -I
 else
 CXXFLAGS   = -DWITHGPU -m64 -mssse3 -Wno-unused-result -Wno-write-strings -O2 -I. -I$(CUDA)/include
 endif
-LFLAGS     = -lpthread -L$(CUDA)/lib64 -lcudart
+LFLAGS     = -lpthread -lcrypto -L$(CUDA)/lib64 -lcudart
 
 else
 
@@ -60,7 +60,7 @@ CXXFLAGS   = -m64 -mssse3 -Wno-unused-result -Wno-write-strings -g -I. -I$(CUDA)
 else
 CXXFLAGS   =  -m64 -mssse3 -Wno-unused-result -Wno-write-strings -O2 -I. -I$(CUDA)/include
 endif
-LFLAGS     = -lpthread
+LFLAGS     = -lpthread -lcrypto
 
 endif
 

--- a/Merge.cpp
+++ b/Merge.cpp
@@ -149,7 +149,12 @@ bool Kangaroo::MergeWork(std::string& file1,std::string& file2,std::string& dest
 
   // Set starting parameters
   keysToSearch.clear();
+  keysHash160.clear();
   keysToSearch.push_back(k1);
+  uint8_t h[20];
+  GetPubKeyHash160(k1,h);
+  keysHash160.push_back(std::array<uint8_t,20>());
+  memcpy(keysHash160.back().data(),h,20);
   keyIdx = 0;
   collisionInSameHerd = 0;
   rangeStart.Set(&RS1);

--- a/Network.cpp
+++ b/Network.cpp
@@ -1249,7 +1249,12 @@ bool Kangaroo::GetConfigFromServer() {
   ::printf("Succesfully connected to server: %s (Version %d)\n",serverIp.c_str(),version);
 
   keysToSearch.clear();
+  keysHash160.clear();
   keysToSearch.push_back(key);
+  uint8_t h[20];
+  GetPubKeyHash160(key,h);
+  keysHash160.push_back(std::array<uint8_t,20>());
+  memcpy(keysHash160.back().data(),h,20);
   return true;
 
 }

--- a/PartMerge.cpp
+++ b/PartMerge.cpp
@@ -327,7 +327,12 @@ bool Kangaroo::MergeWorkPartPart(std::string& part1Name,std::string& part2Name) 
   // Set starting parameters
   endOfSearch = false;
   keysToSearch.clear();
+  keysHash160.clear();
   keysToSearch.push_back(k1);
+  uint8_t h[20];
+  GetPubKeyHash160(k1,h);
+  keysHash160.push_back(std::array<uint8_t,20>());
+  memcpy(keysHash160.back().data(),h,20);
   keyIdx = 0;
   collisionInSameHerd = 0;
   rangeStart.Set(&RS1);
@@ -463,7 +468,12 @@ bool Kangaroo::FillEmptyPartFromFile(std::string& partName,std::string& fileName
   // Save header
   dpSize = dp1;
   keysToSearch.clear();
+  keysHash160.clear();
   keysToSearch.push_back(k1);
+  uint8_t h[20];
+  GetPubKeyHash160(k1,h);
+  keysHash160.push_back(std::array<uint8_t,20>());
+  memcpy(keysHash160.back().data(),h,20);
   keyIdx = 0;
   collisionInSameHerd = 0;
   rangeStart.Set(&RS1);
@@ -636,7 +646,12 @@ bool Kangaroo::MergeWorkPart(std::string& partName,std::string& file2,bool print
 
   // Set starting parameters
   keysToSearch.clear();
+  keysHash160.clear();
   keysToSearch.push_back(k1);
+  uint8_t h2[20];
+  GetPubKeyHash160(k1,h2);
+  keysHash160.push_back(std::array<uint8_t,20>());
+  memcpy(keysHash160.back().data(),h2,20);
   keyIdx = 0;
   collisionInSameHerd = 0;
   rangeStart.Set(&RS1);

--- a/README.md
+++ b/README.md
@@ -3,6 +3,13 @@
 A Pollard's kangaroo interval ECDLP solver for SECP256K1 (based on VanitySearch engine).\
 **This program is limited to a 125bit interval search.**
 
+## Build requirements
+
+- A C++ compiler such as `g++`
+- `make`
+- OpenSSL development libraries (e.g. `libssl-dev` on Debian/Ubuntu)
+- Optional: NVIDIA CUDA Toolkit for GPU acceleration
+
 # Feature
 
 <ul>
@@ -55,13 +62,14 @@ Kangaroo [-v] [-t nbThread] [-d dpBit] [gpu] [-check]
 
 Structure of the input file:
 * All values are in hex format
+* Each key line may contain either a public key alone or a pair "hash160 publicKey"
 * Public keys can be given either in compressed or uncompressed format
 
 ```
 Start range
 End range
-Key #1
-Key #2
+[hash160] Key #1
+[hash160] Key #2
 ...
 ```
 
@@ -70,7 +78,7 @@ ex
 ```
 49dccfd96dc5df56487436f5a1b18c4f5d34f65ddb48cb5e0000000000000000
 49dccfd96dc5df56487436f5a1b18c4f5d34f65ddb48cb5effffffffffffffff
-0459A3BFDAD718C9D3FAC7C187F1139F0815AC5D923910D516E186AFDA28B221DC994327554CED887AAE5D211A2407CDD025CFC3779ECB9C9D7F2F1A1DDF3E9FF8
+f8c2bf34c646831b6bf2192c05edc9857624a8fe 0459A3BFDAD718C9D3FAC7C187F1139F0815AC5D923910D516E186AFDA28B221DC994327554CED887AAE5D211A2407CDD025CFC3779ECB9C9D7F2F1A1DDF3E9F
 0335BB25364370D4DD14A9FC2B406D398C4B53C85BE58FCC7297BD34004602EBEC
 ```
 

--- a/Timer.h
+++ b/Timer.h
@@ -20,6 +20,7 @@
 
 #include <time.h>
 #include <string>
+#include <stdint.h>
 #ifdef WIN64
 #include <windows.h>
 #endif

--- a/hash160.cpp
+++ b/hash160.cpp
@@ -1,0 +1,9 @@
+#include "hash160.h"
+#include <openssl/sha.h>
+#include <openssl/ripemd.h>
+
+void Hash160(const uint8_t *data, size_t len, uint8_t out[20]) {
+    uint8_t sha[SHA256_DIGEST_LENGTH];
+    SHA256(data, len, sha);
+    RIPEMD160(sha, SHA256_DIGEST_LENGTH, out);
+}

--- a/hash160.h
+++ b/hash160.h
@@ -1,0 +1,9 @@
+#ifndef HASH160_H
+#define HASH160_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+void Hash160(const uint8_t *data, size_t len, uint8_t out[20]);
+
+#endif // HASH160_H


### PR DESCRIPTION
## Summary
- allow config file lines to start with a hash160 before the public key
- document optional `hash160` field in README

## Testing
- `make clean && make -j4`
- `make -j4`


------
https://chatgpt.com/codex/tasks/task_e_68b159c14ce8833287426e669f217f5f